### PR TITLE
[im-t2624]: Update Barefoot and Interface Masters SONiC related packages.

### DIFF
--- a/sonic-barefoot-pkgs/bfnplatform_1.0.0_amd64.deb
+++ b/sonic-barefoot-pkgs/bfnplatform_1.0.0_amd64.deb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eff7539164a389a5b21ac0a17a04a9773b790d6ac29e34a2b97bc6fc09816456
-size 265468
+oid sha256:48af533ecb8529c0b2dbac1681b5257a82a872bd2ac4cfa3f332f9b10a9b9e92
+size 266476

--- a/sonic-barefoot-pkgs/bfnsdk_1.0.0_amd64.deb
+++ b/sonic-barefoot-pkgs/bfnsdk_1.0.0_amd64.deb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d189e7e1e02aa1a05207a802c0c8885ce14a7a553849c9cc27e1d886b41188a8
-size 51296710
+oid sha256:4ddfc3554aaa2725ee3ebf2be1d10ffb0537025a5e12844f26dbe420aacde639
+size 51123714

--- a/sonic-imt-boardkeeper-pkgs/boardkeeper-modules_3.01_amd64.deb
+++ b/sonic-imt-boardkeeper-pkgs/boardkeeper-modules_3.01_amd64.deb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:392a7ffb6c223f619211c88237bcc1a283b4fc0b668b42b2b66e27a219c5384c
-size 14183562
+oid sha256:8440c934c6a6e23cb71c83eec63ca6f5fd446de034a9b5cc0c056bada94be0fc
+size 7486554


### PR DESCRIPTION
```
[im-t2624]: Update Barefoot and Interface Masters SONiC related packages
        imt-sdk:
            branch: master
            commit: cc83da641b6d8e70788c3b04cddedd4c8065e623
            change: Enable i2c bitbanged for psu bus.
        bfn-sde:
            branch: master
            commit: af7002de1453c66f2cd070b94605a22f2510c78c
            change: Updated CLI commands.
```